### PR TITLE
cpd_make: fixed Matlab-API change on fileparts().

### DIFF
--- a/core/cpd_make.m
+++ b/core/cpd_make.m
@@ -20,7 +20,9 @@
 
 function cpd_make()
 
-psave=pwd; p = mfilename('fullpath'); [pathstr, name, ext, versn] = fileparts(p);
+psave=pwd;
+p = mfilename('fullpath');
+[pathstr, name, ext] = fileparts(p);
 
 %%%%%%%%%%%%%%%%%%%% cpd_P %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
cpd_make() failed on Matlab 2014a, the problem was that `fileparts` returns now 3 results, not 4. The fix is simple as `name`, `ext` and `versn` weren't used anyway.
